### PR TITLE
Potential fix for code scanning alert no. 1: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/storage/mroonga/vendor/groonga/vendor/download_mecab.rb
+++ b/storage/mroonga/vendor/groonga/vendor/download_mecab.rb
@@ -42,7 +42,7 @@ def download(url, base)
 
   tar = "#{base}.tar"
   tar_gz = "#{tar}.gz"
-  open(url, :ssl_verify_mode => ssl_verify_mode) do |remote_tar_gz|
+  URI.open(url, :ssl_verify_mode => ssl_verify_mode) do |remote_tar_gz|
     File.open(tar_gz, "wb") do |local_tar_gz|
       local_tar_gz.print(remote_tar_gz.read)
     end


### PR DESCRIPTION
Potential fix for [https://github.com/pwnlaboratory/server/security/code-scanning/1](https://github.com/pwnlaboratory/server/security/code-scanning/1)

To fix the problem, we should replace the use of `Kernel.open` with a safer alternative. In this case, we can use `URI.open` instead of `Kernel.open` to handle the URL. This change will mitigate the risk of arbitrary code execution by ensuring that the URL is treated as a URI and not as a shell command.

We need to modify the `download` method to use `URI.open` instead of `open`. Additionally, we need to ensure that the `open-uri` library is properly required to use `URI.open`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
